### PR TITLE
Add a few more docstrings

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,12 +14,13 @@ makedocs(;
         ],
         "Vectorized Convenience Functions" => "vectorized_convenience_functions.md",
         "Future Work" => "future_work.md",
+        "API reference" => "api.md",
         "Developer Documentation" => [
             "devdocs/overview.md",
             "devdocs/loopset_structure.md",
-	    "devdocs/constructing_loopsets.md",
-	    "devdocs/evaluating_loops.md",
-	    "devdocs/lowering.md"
+            "devdocs/constructing_loopsets.md",
+            "devdocs/evaluating_loops.md",
+            "devdocs/lowering.md"
         ]
     ],
     # repo="https://github.com/chriselrod/LoopVectorization.jl/blob/{commit}{path}#L{line}",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,26 @@
+# API reference
+
+## Macros
+
+```@docs
+@avx
+@_avx
+```
+
+## `map`-like constructs
+
+```@docs
+vmap
+vmap!
+vmapnt
+vmapnt!
+vmapntt
+vmapntt!
+```
+
+## `filter`-like constructs
+
+```@docs
+vfilter
+vfilter!
+```

--- a/src/LoopVectorization.jl
+++ b/src/LoopVectorization.jl
@@ -47,6 +47,18 @@ include("condense_loopset.jl")
 include("reconstruct_loopset.jl")
 include("constructors.jl")
 
+"""
+LoopVectorization provides macros and functions that combine SIMD vectorization and
+loop-reordering so as to improve performance:
+
+- [`@avx`](@ref): transform `for`-loops and broadcasting
+- [`@_avx`](@ref): similar to `@avx` but does not use type information
+- [`vmap`](@ref) and `vmap!`: vectorized version of `map` and `map!`
+- [`vmapnt`](@ref) and `vmapnt!`: non-temporal variants of `vmap` and `vmap!`
+- [`vmapntt`](@ref) and `vmapntt!`: threaded variants of `vmapnt` and `vmapnt!`
+- [`vfilter`](@ref) and `vfilter!`: vectorized versions of `filter` and `filter!`
+"""
+LoopVectorization
 
 include("precompile.jl")
 _precompile_()

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -66,7 +66,8 @@ Annotate a `for` loop, or a set of nested `for` loops whose bounds are constant 
         end
     end
 
-The macro models the set of nested loops, and chooses a 
+The macro models the set of nested loops, and chooses an ordering of the three loops to
+minimize predicted computation time.
 
 It may also apply to broadcasts:
 
@@ -81,7 +82,7 @@ julia> c = similar(b);
 
 julia> @avx @. c = exp(2a);
 
-julia> b ≈ c 
+julia> b ≈ c
 true
 ```
 
@@ -148,8 +149,9 @@ end
 """
     @_avx
 
-This macro transforms loops, making default assumptions rather than punting to a generated
-function that is often capable of using type information in place of some assumptions.
+This macro transforms loops similarly to [`@avx`](@ref).
+While `@avx` punts to a generated function to enable type-based analysis, `_@avx`
+works on just the expressions. This requires that it makes a number of default assumptions.
 """
 macro _avx(q)
     esc(lower(LoopSet(q, __module__)))
@@ -164,4 +166,3 @@ end
 macro avx_debug(q)
     esc(LoopVectorization.setup_call_debug(LoopSet(q, __module__)))
 end
-

--- a/src/costs.jl
+++ b/src/costs.jl
@@ -68,7 +68,7 @@ function vector_cost(ic::InstructionCost, Wshift, sizeof_T)
     else # we assume custom cost, and that latency == recip_throughput
         scaling = ic.scaling
         sl, srt = round(Int,scaling), scaling
-    end    
+    end
     srt, sl, srp
 end
 # instruction_cost(instruction::Symbol) = get(COST, instruction, OPAQUE_INSTRUCTION)
@@ -278,7 +278,7 @@ function reduction_combine_to(x::Float64)
     x == 1.0 ? :reduce_to_add : x == 2.0 ? :reduce_to_prod : x == 5.0 ? :reduce_to_max : x == 6.0 ? :reduce_to_min : throw("Reduction not found.")
 end
 reduction_combine_to(x) = reduction_combine_to(reduction_instruction_class(x))
-function reduction_zero(x::Float64) 
+function reduction_zero(x::Float64)
     # x == 1.0 ? :zero : x == 2.0 ? :one : x == 3.0 ? :false : x == 4.0 ? :true : x == 5.0 ? :typemin : x == 6.0 ? :typemax : throw("Reduction not found.")
     x == 1.0 ? :zero : x == 2.0 ? :one : x == 5.0 ? :typemin : x == 6.0 ? :typemax : throw("Reduction not found.")
 end
@@ -373,4 +373,3 @@ const FUNCTIONSYMBOLS = Dict{Type{<:Function},Instruction}(
     typeof(ifelse) => :vifelse,
     typeof(vifelse) => :vifelse
 )
-

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -30,3 +30,16 @@ if (Base.libllvm_version ≥ v"7" && VectorizationBase.AVX512F) || Base.libllvm_
 end
 vfilter(f, y) = filter(f, y)
 
+"""
+    vfilter(f, a::AbstractArray)
+
+SIMD-vectorized `filter`, returning an array containing the elements of `a` for which `f` return `true`.
+"""
+vfilter
+
+"""
+    vfilter!(f, a::AbstractArray)
+
+SIMD-vectorized `filter!`, removing the element of `a` for which `f` is false.
+"""
+vfilter!


### PR DESCRIPTION
Other than `_avx_!`, every export is documented including `LoopVectorization` itself. (I don't always remember, but I often like to provide a brief API summary of a package in the module's docstring). It also adds a new API reference page to the Documenter docs. 

Sorry about the whitespace changes, my Atom settings do it automatically.