### PR TITLE
Preserve names of arrays and iteration variables across generated boundary

### DIFF
--- a/src/condense_loopset.jl
+++ b/src/condense_loopset.jl
@@ -4,11 +4,13 @@
 Base.:|(u::Unsigned, it::IndexType) = u | UInt8(it)
 Base.:(==)(u::Unsigned, it::IndexType) = (u % UInt8) == UInt8(it)
 
-struct ArrayRefStruct
+struct ArrayRefStruct{array,ptr}
     index_types::UInt64
     indices::UInt64
     offsets::UInt64
 end
+array(ar::ArrayRefStruct{a,p}) where {a,p} = a
+ptr(ar::ArrayRefStruct{a,p}) where {a,p}   = p
 
 function findindoradd!(v::Vector{T}, s::T) where {T}
     ind = findfirst(sᵢ -> sᵢ == s, v)
@@ -43,7 +45,7 @@ function ArrayRefStruct(ls::LoopSet, mref::ArrayReferenceMeta, arraysymbolinds::
             end
         end
     end
-    ArrayRefStruct( index_types, indices, offsets )
+    ArrayRefStruct{mref.ref.array,mref.ptr}( index_types, indices, offsets )
 end
 
 struct OperationStruct <: AbstractLoopOperation
@@ -189,14 +191,15 @@ end
 @inline array_wrapper(A::SubArray) = A.indices
 
 
-
+# If you change the number of arguments here, make commensurate changes
+# to the `insert!` locations in `setup_call_noinline`.
 @generated function __avx__!(
-    ::Val{UT}, ::Type{OPS}, ::Type{ARF}, ::Type{AM}, lb::LB,
+    ::Val{UT}, ::Type{OPS}, ::Type{ARF}, ::Type{AM}, ::Type{LPSYM}, lb::LB,
     ::Val{AR}, ::Val{D}, ::Val{IND}, subsetvals, arraydescript, vargs::Vararg{<:Any,N}
-) where {UT, OPS, ARF, AM, LB, N, AR, D, IND}
+) where {UT, OPS, ARF, AM, LPSYM, LB, N, AR, D, IND}
     num_vptrs = length(ARF.parameters)::Int
     vptrs = [gensym(:vptr) for _ ∈ 1:num_vptrs]
-    call = Expr(:call, lv(:_avx_!), Val{UT}(), OPS, ARF, AM, :lb)
+    call = Expr(:call, lv(:_avx_!), Val{UT}(), OPS, ARF, AM, LPSYM, :lb)
     for n ∈ 1:num_vptrs
         push!(call.args, vptrs[n])
     end
@@ -241,13 +244,14 @@ function generate_call(ls::LoopSet, IUT, debug::Bool = false)
     foreach(ref -> push!(arrayref_descriptions.args, ArrayRefStruct(ls, ref, arraysymbolinds)), ls.refs_aliasing_syms)
     argmeta = argmeta_and_consts_description(ls, arraysymbolinds)
     loop_bounds = loop_boundaries(ls)
+    loop_syms = Expr(:curly, :Tuple, map(QuoteNode, ls.loopsymbols)...)
     inline, U, T = IUT
     if inline | debug
         func = debug ? lv(:_avx_loopset_debug) : lv(:_avx_!)
         lbarg = debug ? Expr(:call, :typeof, loop_bounds) : loop_bounds
         q = Expr(
             :call, func, Expr(:call, Expr(:curly, :Val, (U,T))),
-            operation_descriptions, arrayref_descriptions, argmeta, lbarg
+            operation_descriptions, arrayref_descriptions, argmeta, loop_syms, lbarg
         )
         debug && deleteat!(q.args, 2)
         foreach(ref -> push!(q.args, vptr(ref)), ls.refs_aliasing_syms)
@@ -255,7 +259,7 @@ function generate_call(ls::LoopSet, IUT, debug::Bool = false)
         arraydescript = Expr(:tuple)
         q = Expr(
             :call, lv(:__avx__!), Expr(:call, Expr(:curly, :Val, (U,T))),
-            operation_descriptions, arrayref_descriptions, argmeta, loop_bounds, arraydescript
+            operation_descriptions, arrayref_descriptions, argmeta, loop_syms, loop_bounds, arraydescript
         )
         for array ∈ ls.includedactualarrays
             push!(q.args, Expr(:call, lv(:unwrap_array), array))
@@ -315,10 +319,10 @@ function setup_call_noinline(ls::LoopSet, U = zero(Int8), T = zero(Int8))
         end
         push!(q.args, ex)
     end
-    insert!(call.args, 7, Expr(:call, Expr(:curly, :Val, vptrarrays)))
-    insert!(call.args, 8, Expr(:call, Expr(:curly, :Val, vptrsubsetdims)))
-    insert!(call.args, 9, Expr(:call, Expr(:curly, :Val, vptrindices)))
-    insert!(call.args, 10, vptrsubsetvals)
+    insert!(call.args, 8, Expr(:call, Expr(:curly, :Val, vptrarrays)))
+    insert!(call.args, 9, Expr(:call, Expr(:curly, :Val, vptrsubsetdims)))
+    insert!(call.args, 10, Expr(:call, Expr(:curly, :Val, vptrindices)))
+    insert!(call.args, 11, vptrsubsetvals)
     if hasouterreductions
         outer_reducts = Expr(:local)
         for or ∈ ls.outer_reductions


### PR DESCRIPTION
Fixes #74