### PR TITLE
WIP: shorten compile time with nospecialize

### DIFF
--- a/src/LoopVectorization.jl
+++ b/src/LoopVectorization.jl
@@ -25,6 +25,7 @@ export LowDimArray, stridedpointer, vectorizable,
 
 include("vectorizationbase_extensions.jl")
 include("predicates.jl")
+include("typeutils.jl")
 include("map.jl")
 include("filter.jl")
 include("costs.jl")

--- a/src/reconstruct_loopset.jl
+++ b/src/reconstruct_loopset.jl
@@ -83,8 +83,9 @@ function add_mref!(ls::LoopSet, ar::ArrayReferenceMeta, i::Int, ::Type{OffsetStr
 end
 
 function add_mref!(
-    ls::LoopSet, ar::ArrayReferenceMeta, i::Int, ::Type{S}
-) where {T, X <: Tuple, S <: VectorizationBase.AbstractStaticStridedPointer{T,X}}
+    ls::LoopSet, ar::ArrayReferenceMeta, i::Int, @nospecialize(S::Type{<:VectorizationBase.AbstractStaticStridedPointer})
+)
+    T, X = abstractparameters(S, VectorizationBase.AbstractStaticStridedPointer)
     if last(X.parameters)::Int == 1
         pushvarg′!(ls, ar, i)
     else

--- a/src/typeutils.jl
+++ b/src/typeutils.jl
@@ -1,0 +1,21 @@
+# @nospecialize  # don't specialize anything until @specialize
+
+"""
+    params = abstractparameters(T::Type, AT::Type)
+
+For a type `T` which is a subtype of `AT{params...}`, return `params`.
+The purpose of this function is to allow one to use `@nospecialize` on type-arguments
+and still extract the parameters of the corresponding abstract type.
+"""
+function abstractparameters(T::Type, AT::Type)
+    @nospecialize T AT
+    @assert T <: AT
+    Tst = supertype(T)
+    while Tst <: AT
+        T = Tst
+        Tst = supertype(T)
+    end
+    return T.parameters
+end
+
+# @specialize

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1,3 +1,5 @@
+using LoopVectorization, LinearAlgebra, Test
+
 @testset "broadcast" begin
     M, N = 37, 47
     # M = 77;


### PR DESCRIPTION
This is a branch that, for the moment, is mostly for https://github.com/JuliaLang/julia/issues/35131. Steps to reproduce: after `dev`ing this branch, do

```julia
julia> using LoopVectorization

shell> pwd
/home/tim/.julia/dev/LoopVectorization/test

julia> include("broadcast.jl")
(T, #= /home/tim/.julia/dev/LoopVectorization/test/broadcast.jl:7 =# @__LINE__()) = (Float32, 7)
(T, #= /home/tim/.julia/dev/LoopVectorization/test/broadcast.jl:7 =# @__LINE__()) = (Float64, 7)
(T, #= /home/tim/.julia/dev/LoopVectorization/test/broadcast.jl:7 =# @__LINE__()) = (Int32, 7)
(T, #= /home/tim/.julia/dev/LoopVectorization/test/broadcast.jl:7 =# @__LINE__()) = (Int64, 7)
Test Summary: | Pass  Total
broadcast     |   74     74
Test.DefaultTestSet("broadcast", Any[], 74, false)

julia> include("/home/tim/src/julia/nspecializations.jl")   # just if you want a quick count
allmethods (generic function with 1 method)

julia> nspecializations(first(methods(LoopVectorization.abstractparameters)))
33
```
To be clear, the point of `abstractparameters` is to allow one to write certain methods without a `where` clause and still be able to access the parameters. I am assuming that having the `where` will force specialization independent of a `@nospecialize`. (If that's not correct, I'd rather get rid of `abstractparameters` and go back to the way they were before.) So it's ironic that `abstractparameters` itself seems to get inferred for many different input types.