### PR TITLE
Add more documentation on the internals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Chris Elrod <elrodc@gmail.com>"]
 version = "0.7.0"
 
 [deps]
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 SIMDPirates = "21efa798-c60a-11e8-04d3-e1a92915a26a"
@@ -12,6 +13,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
+DocStringExtensions = "0.8"
 OffsetArrays = "1"
 SIMDPirates = "0.7.13"
 SLEEFPirates = "0.4.4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,7 +21,8 @@ makedocs(;
             "devdocs/loopset_structure.md",
             "devdocs/constructing_loopsets.md",
             "devdocs/evaluating_loops.md",
-            "devdocs/lowering.md"
+            "devdocs/lowering.md",
+            "devdocs/reference.md"
         ]
     ],
     # repo="https://github.com/chriselrod/LoopVectorization.jl/blob/{commit}{path}#L{line}",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -22,5 +22,5 @@ vmapntt!
 
 ```@docs
 vfilter
-vfilter!
+LoopVectorization.vfilter!
 ```

--- a/docs/src/devdocs/reference.md
+++ b/docs/src/devdocs/reference.md
@@ -1,0 +1,42 @@
+# Internals reference
+
+## Operation types
+
+```@docs
+LoopVectorization.OperationType
+LoopVectorization.constant
+LoopVectorization.memload
+LoopVectorization.compute
+LoopVectorization.memstore
+LoopVectorization.loopvalue
+```
+
+## Operation
+
+```@docs
+LoopVectorization.Operation
+```
+
+## Instructions and costs
+
+```@docs
+LoopVectorization.Instruction
+LoopVectorization.InstructionCost
+```
+
+## Array references
+
+```@docs
+LoopVectorization.ArrayReference
+LoopVectorization.ArrayReferenceMeta
+```
+
+## Condensed types
+
+These are used when encoding the `@avx` block as a type parameter for passing through
+to the `@generated` function.
+
+```@docs
+LoopVectorization.ArrayRefStruct
+LoopVectorization.OperationStruct
+```

--- a/src/LoopVectorization.jl
+++ b/src/LoopVectorization.jl
@@ -16,6 +16,7 @@ using SLEEFPirates: pow
 using Base.Broadcast: Broadcasted, DefaultArrayStyle
 using LinearAlgebra: Adjoint, Transpose
 using Base.Meta: isexpr
+using DocStringExtensions
 
 
 const SUPPORTED_TYPES = Union{Float16,Float32,Float64,Integer}

--- a/src/condense_loopset.jl
+++ b/src/condense_loopset.jl
@@ -5,7 +5,9 @@ Base.:|(u::Unsigned, it::IndexType) = u | UInt8(it)
 Base.:(==)(u::Unsigned, it::IndexType) = (u % UInt8) == UInt8(it)
 
 """
-`ArrayRefStruct` stores a representation of an array-reference expression such as `A[i,j]`.
+    ArrayRefStruct
+
+A condensed representation of an [`ArrayReference`](@ref).
 It supports array-references with up to 8 indexes, where the data for each consecutive index is packed into corresponding 8-bit fields
 of `index_types` (storing the enum `IndexType`), `indices` (the `id` for each index symbol), and `offsets` (currently unused).
 """
@@ -53,6 +55,11 @@ function ArrayRefStruct(ls::LoopSet, mref::ArrayReferenceMeta, arraysymbolinds::
     ArrayRefStruct{mref.ref.array,mref.ptr}( index_types, indices, offsets )
 end
 
+"""
+    OperationStruct
+
+A condensed representation of an [`Operation`](@ref).
+"""
 struct OperationStruct <: AbstractLoopOperation
     # instruction::Instruction
     loopdeps::UInt64

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -90,6 +90,29 @@ julia> b ≈ c
 true
 ```
 
+# Extended help
+
+Advanced users can customize the implementation of the `@avx`-annotated block
+using keyword arguments:
+
+```
+@avx inline=false unroll=2 body
+```
+
+where `body` is the code of the block (e.g., `for ... end`).
+
+`inline` is a Boolean. When `true` (the default), `body` will be directly inlined
+into the function (via a forced-inlining call to `_avx_!`).
+When `false`, it will call `__avx__!` instead, letting Julia's own inlining engine
+determine whether the call to `__avx__!` should be inlined. (Typically, it won't.)
+In priniciple, first calling `__avx__!` (which itself calls `_avx_!`) can sometimes
+allow better code generation.
+One can find some circumstances where `inline=true` is faster, and other circumstances
+where `inline=false` is faster, so the best setting may require experimentation.
+
+`unroll` is an integer that specifies the loop unrolling factor, or a
+tuple `(4, 2)` signaling that the generated code should unroll more than
+one loop.
 """
 macro avx(q)
     q = macroexpand(__module__, q)
@@ -121,7 +144,7 @@ function check_unroll(arg)
             T = convert(Int8, tup.args[2])
         else
             return nothing
-        end    
+        end
     else
         return nothing
     end
@@ -179,4 +202,3 @@ macro avx_debug(q)
     q = macroexpand(__module__, q)
     esc(LoopVectorization.setup_call_debug(LoopSet(q, __module__)))
 end
-

--- a/src/costs.jl
+++ b/src/costs.jl
@@ -6,7 +6,12 @@ else
 end
 
 
+"""
+    Instruction
 
+`Instruction` represents a function via its module and symbol. It is
+similar to a `GlobalRef` and may someday be replaced by `GlobalRef`.
+"""
 struct Instruction
     mod::Symbol
     instr::Symbol
@@ -36,10 +41,24 @@ Base.isequal(ins1::Instruction, ins2::Instruction) = (ins1.instr === ins2.instr)
 
 const LOOPCONSTANT = Instruction(Symbol("LOOPCONSTANTINSTRUCTION"))
 
+"""
+    InstructionCost
+
+Store parameters related to performance for individual CPU instructions.
+
+$(TYPEDFIELDS)
+"""
 struct InstructionCost
+    "A flag indicating how instruction cost scales with vector width (128, 256, or 512 bits)"
     scaling::Float64 # sentinel values: -3 == no scaling; -2 == offset_scaling, -1 == linear scaling, >0 ->  == latency == reciprocal throughput
+    """The number of clock cycles per operation when many of the same operation are repeated in sequence.
+    Think of it as the inverse of the flow rate at steady-state. It is typically ≤ the `scalar_latency`."""
     scalar_reciprocal_throughput::Float64
+    """The minimum delay, in clock cycles, associated with the instruction.
+    Think of it as the delay from turning on a faucet to when water starts coming out the end of the pipe.
+    See also `scalar_reciprocal_throughput`."""
     scalar_latency::Int
+    "Number of floating-point registered used"
     register_pressure::Int
 end
 InstructionCost(sl::Int, srt::Float64, scaling::Float64 = -3.0) = InstructionCost(scaling, srt, sl, 0)

--- a/test/offsetarrays.jl
+++ b/test/offsetarrays.jl
@@ -180,7 +180,7 @@ T = Float64
            out[I] = tmp
        end
        out
-   end
+    end
     function avxgeneric2!(out, A, kern)
        @avx for I in CartesianIndices(out)
            tmp = zero(eltype(out))
@@ -225,7 +225,7 @@ T = Float64
         @test avxgeneric!(out4, A, kern) ≈ out1
         fill!(out4, NaN);
         @test avxgeneric!(out4, A, skern) ≈ out1
-        
+
         fill!(out4, NaN); @test avxgeneric2!(out4, A, kern) ≈ out1
         fill!(out4, NaN); @test avxgeneric2!(out4, A, skern) ≈ out1
     end


### PR DESCRIPTION
While most of this should hopefully be OK, notice that I've embedded a number of questions where I am uncertain of the answer. It would be best to resolve or delete these questions before merging. @chriselrod, you are authorized to just edit the files or answer here and I will make changes.

One oddity: Documenter complains about not being able to find the docstring for `LoopVectorization.vfilter!` and then later complains that we didn't put it in a `@docs` block. I am confused by this.

Hope the additional dependency on DocStringExtensions is OK. If not, we can delete it.