### PR TITLE
Run CI on more architectures and more operating systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,14 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
+          - macos-latest
           - windows-latest
         arch:
           - x64
+          - x86
+        exclude:
+          - os: macOS-latest
+            arch: x86 # 32-bit Julia binaries are not available on macOS
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
Before this pull request, we run CI on the following OS+arch combinations:
- Linux x64
- Windows x64

After this pull request, we run CI on the following OS+arch combinations:
- Linux x64
- Windows x64
- macOS x64
- Linux x86
- Windows x86