### PR TITLE
Add Zygote gradient for `vmap`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 SLEEFPirates = "476501e8-09a2-5ece-8869-fb82de89a1fa"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
+ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 ArrayInterface = "2.14.2"
@@ -27,6 +28,7 @@ julia = "1.5"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["InteractiveUtils", "Random", "Test"]
+test = ["InteractiveUtils", "Random", "Test", "Zygote"]

--- a/src/LoopVectorization.jl
+++ b/src/LoopVectorization.jl
@@ -82,6 +82,7 @@ include("constructors.jl")
 include("user_api_conveniences.jl")
 include("mapreduce.jl")
 include("broadcast.jl")
+include("zygoterules.jl")
 
 """
 LoopVectorization provides macros and functions that combine SIMD vectorization and

--- a/src/zygoterules.jl
+++ b/src/zygoterules.jl
@@ -1,0 +1,64 @@
+
+import ZygoteRules # ChainRules doesn't yet allow calling AD inside a rule, like _pullback
+
+ZygoteRules.@adjoint function vmap(f, args::AbstractArray...)
+    ∇vmap(__context__, f, args...)
+end
+
+function ∇vmap(cx, f, args...)
+    ys_and_backs = vmap((xs...) -> ZygoteRules._pullback(cx, f, xs...), args...)
+    if isempty(ys_and_backs)
+        println("got empty case!")
+        return ys_and_backs, _ -> nothing
+    else
+        ys, backs = _zygote_unzip(ys_and_backs)
+        function back(Δ)
+            # Δf_and_args = _zygote_unzip(vmap((b, δ) -> b(δ), backs, Δ)) # MethodError: no method matching map!(::LoopVectorization.var"#601#606", ::Array{Tuple{Nothing,Float64},1}, ::Array{Zygote.var"#1848#back#217"{Zygote.var"#215#216"{Float64}},1}, ::Tuple{Float64,Float64,Float64})
+            Δf_and_args = _zygote_unzip(map((b, δ) -> b(δ), backs, Δ))
+            Δf = reduce(_zygote_accum, Δf_and_args[1])
+            (Δf, Δf_and_args[2:end]...)
+        end
+        back(::Nothing) = map(_ -> nothing, ys_and_backs)
+        return ys, back
+    end
+end
+
+# unzip -- from src/lib/array.jl
+
+struct _zygote_StaticGetter{i} end
+
+(::_zygote_StaticGetter{i})(v) where {i} = v[i]
+
+function _zygote_unzip(tuples)
+    N = length(first(tuples))
+    _zygote__unzip(tuples, Val(N))
+end
+
+@generated function _zygote__unzip(tuples, ::Val{N}) where {N}
+    Expr(:tuple, [:(map($(_zygote_StaticGetter{i}()), tuples)) for i in 1:N]...)
+end
+
+# accum -- from src/lib/lib.jl
+
+_zygote_accum() = nothing
+_zygote_accum(x) = x
+
+_zygote_accum(x, y) =
+  x === nothing ? y :
+  y === nothing ? x :
+  x + y
+
+_zygote_accum(x, y, zs...) = _zygote_accum(_zygote_accum(x, y), zs...)
+
+_zygote_accum(x::Tuple, y::Tuple) = _zygote_accum.(x, y)
+_zygote_accum(x::AbstractArray, y::AbstractArray) = _zygote_accum.(x, y)
+
+@generated function _zygote_accum(x::NamedTuple, y::NamedTuple)
+  grad(x) = x in fieldnames(y) ? :(y.$x) : :nothing
+  Expr(:tuple, [:($f=_zygote_accum(x.$f, $(grad(f)))) for f in fieldnames(x)]...)
+end
+
+function _zygote_accum(x::Base.RefValue, y::Base.RefValue)
+  @assert x === y
+  return x
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,9 @@ const RUN_SLOW_TESTS = LoopVectorization.REGISTER_COUNT ≤ 16 || !parse(Bool, g
 
 @time @testset "LoopVectorization.jl" begin
     
+    @time include("zygoterules.jl")
+    # move down, later!
+
     @test isempty(detect_unbound_args(LoopVectorization))
 
     @time include("printmethods.jl")

--- a/test/zygoterules.jl
+++ b/test/zygoterules.jl
@@ -1,0 +1,45 @@
+using Zygote
+
+function ngradient(f, xs::AbstractArray...)
+  grads = zero.(xs)
+  for (x, Δ) in zip(xs, grads), i in 1:length(x)
+    δ = sqrt(eps())
+    tmp = x[i]
+    x[i] = tmp - δ/2
+    y1 = f(xs...)
+    x[i] = tmp + δ/2
+    y2 = f(xs...)
+    x[i] = tmp
+    Δ[i] = (y2-y1)/δ
+  end
+  return grads
+end
+
+function gradcheck(f, xs...)
+  grad_zygote = gradient(f, xs...)
+  grad_finite_difference = ngradient(f, xs...)
+  return all(isapprox.(grad_zygote, grad_finite_difference; rtol = 1e-5, atol = 1e-5))
+end
+
+gradtest(f, xs::AbstractArray...) = gradcheck((xs...) -> sum(sin.(f(xs...))), xs...)
+gradtest(f, dims...) = gradtest(f, rand.(Float64, dims)...)
+
+@testset "Zygote adjoint for $mapfunc" for mapfunc in [map, vmap] begin
+    @test gradtest(xs -> sum(mapfunc(x -> x^2, xs)), rand(2,3))
+    @test gradtest((xss...) -> sum(mapfunc((xs...) -> sqrt(sum(xs.^2)), xss...)), [rand(5) for _ in 1:6]...)
+    function foo(y)
+      bar = (x) -> x*y
+      sum(mapfunc(bar, 1:5))
+    end
+    @test gradtest(foo, 3)
+    # @test gradient(v -> sum([x for x in v]), [1.1,2.2,3.3]) == ([1, 1, 1],)
+  # end
+
+  # @testset "Tuple adjoint" begin
+    x = randn(3)
+    _, pb = Zygote.pullback(x -> mapfunc(abs2, x), x)
+    Δy = randn(3)
+    @test first(pb((Δy..., ))) ≈ first(pb(Δy))
+  # end
+end
+end


### PR DESCRIPTION
This is the other half of https://github.com/FluxML/Zygote.jl/pull/842, with the aim of not having Zygote depend directly on this package, just to define one gradient.

It's copied from the Zygote code, but simplified as there is no need to reverse. I can't figure out why that version is able to use `vmap` for the backwards pass, but this gives errors here. But before trying harder, does this sound like a good idea?

I don't think this can be done with ChainRulesCore yet (e.g. https://github.com/JuliaDiff/ChainRules.jl/issues/314), so it uses ZygoteRules. Besides that, it needs `unzip` and `accum` from Zygote, which I've copied here verbatim. Possibly not all their methods are needed. I've also just copied the tests. 