### PR TITLE
Add a test that will fail if the test suite takes more than two hours

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,11 @@
 using Test
 using LoopVectorization
 using LinearAlgebra
-
 import InteractiveUtils
 
 InteractiveUtils.versioninfo(stdout; verbose = true)
 
-# const START_TIME = time()
-# exceeds_time_limit() = (time() - START_TIME) > 35 * 60
+const START_TIME = time()
 
 function clenshaw(x, coeff)
     len_c = length(coeff)
@@ -79,3 +77,6 @@ const RUN_SLOW_TESTS = LoopVectorization.REGISTER_COUNT ≤ 16 || !parse(Bool, g
 
     @time include("gemm.jl")
 end
+
+const ELAPSED_MINUTES = (time() - START_TIME)/60
+@test ELAPSED_MINUTES < 120


### PR DESCRIPTION
Fixes #160 

Right now, if the test suite starts to take a really long time to run, we have no way of noticing (unless we happen to open up the test log).

This pull request adds a single test to the end of the test suite. This test will:
- PASS if the test suite takes two hours or less 
- FAIL if the test suite takes more than two hours

We can certainly change this limit. I picked two hours because, as far as I can tell, none of the jobs take more than 1.5 hours to run.
