### PR TITLE
Remove `println` statements accompanying errors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoopVectorization"
 uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
 authors = ["Chris Elrod <elrodc@gmail.com>"]
-version = "0.9.6"
+version = "0.9.7"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -526,7 +526,7 @@ function register_single_loop!(ls::LoopSet, looprange::Expr)
         U = add_loop_bound!(ls, itersym, Expr(:call, lv(:maybestaticlast), N), true)
         loop = Loop(itersym, L, U)
     else
-        throw("Unrecognized loop range type: $r.")
+        throw(LoopError("Unrecognized loop range type: $r."))
     end
     add_loop!(ls, loop, itersym)
     nothing
@@ -819,6 +819,6 @@ struct LoopError <: Exception
 end
 
 function Base.showerror(io::IO, err::LoopError)
-    printstyled(io, err.msg, '\n'; color = :red)
-    printstyled(io, err.ex)
+    printstyled(io, err.msg; color = :red)
+    isnothing(err.ex) || printstyled(io, '\n', err.ex)
 end

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -621,8 +621,7 @@ function add_operation!(
     elseif RHS.head === :block
         add_operation!(ls, LHS, strip_op_linenumber_nodes(RHS), elementbytes, position)
     else
-        println(RHS)
-        throw("Expression not recognized.")
+        throw(LoopError("Expression not recognized.", RHS))
     end
 end
 add_operation!(ls::LoopSet, RHS::Expr, elementbytes::Int, position::Int) = add_operation!(ls, gensym(:LHS), RHS, elementbytes, position)
@@ -657,8 +656,7 @@ function add_operation!(
     elseif RHS.head === :block
         add_operation!(ls, LHS, strip_op_linenumber_nodes(RHS), elementbytes, position)
     else
-        println(RHS)
-        throw("Expression not recognized.")
+        throw(LoopError("Expression not recognized.", RHS))
     end
 end
 
@@ -722,18 +720,15 @@ function Base.push!(ls::LoopSet, ex::Expr, elementbytes::Int, position::Int)
                         add_compute!(ls, tempunpacksym, f, vparents, elementbytes)
                         add_store_ref!(ls, tempunpacksym, lhsi, elementbytes)
                     else
-                        println(lhsi)
-                        throw("Unpacking the above expression in the left hand side was not understood/supported.")
+                        throw(LoopError("Unpacking the above expression in the left hand side was not understood/supported.", lhsi))
                     end
                 end
                 first(vparents)
             else
-                println(LHS)
-                throw("LHS not understood; only `:ref`s and `:tuple`s are currently supported.")
+                throw(LoopError("LHS not understood; only `:ref`s and `:tuple`s are currently supported.", LHS))
             end
         else
-            println(LHS)
-            throw("LHS not understood.")
+            throw(LoopError("LHS not understood.", LHS))
         end
     elseif ex.head === :block
         add_block!(ls, ex, elementbytes, position)
@@ -756,8 +751,7 @@ function Base.push!(ls::LoopSet, ex::Expr, elementbytes::Int, position::Int)
             add_compute!(ls, LHS, :identity, [RHS], elementbytes)
         end
     else
-        println(ex)
-        throw("Don't know how to handle expression.")
+        throw(LoopError("Don't know how to handle expression.", ex))
     end
 end
 
@@ -817,3 +811,14 @@ end
 #     order[u₁loopnum], order[u₂loopnum]
 # end
 
+
+struct LoopError <: Exception
+    msg
+    ex
+    LoopError(msg, ex=nothing) = new(msg, ex)
+end
+
+function Base.showerror(io::IO, err::LoopError)
+    printstyled(io, err.msg, '\n'; color = :red)
+    printstyled(io, err.ex)
+end

--- a/test/miscellaneous.jl
+++ b/test/miscellaneous.jl
@@ -1139,5 +1139,16 @@ if Base.libllvm_version ≥ v"8" || LoopVectorization.VectorizationBase.SIMD_NAT
         end
     end
 end
+
+@test_throws LoadError @macroexpand begin # pull #172
+    @avx for i in eachindex(xs)
+        if i in axes(ys,1)
+            xs[i] = ys[i]
+        else
+            xs[i] = zero(eltype(ys))
+        end
+    end
+end
+
 end
 


### PR DESCRIPTION
This replaces `println(ex); throw(str)` with an error type, so that if macro expansion fails within a try-catch block, nothing is printed. 

Closes https://github.com/mcabbott/Tullio.jl/issues/26

Example of new behaviour:
```
julia> try                                                                   
       macroexpand(Main, quote                                               
       @avx for i = 𝒶𝓍i                                                      
           if i ∈ (axes)(var"𝛥≪rand(10)≫", 1)                                
               var"𝛥≪rand(10)≫"[i] = var"𝛥≪rand(10)≫"[i] + 𝛥ℛ[i]             
           else                                                              
               (zero)((eltype)(var"𝛥≪rand(10)≫"))                            
           end                                                               
       end                                                                   
       end)                                                                  
       catch err                                                             
       end  # silence!

julia> @macroexpand @avx for i = 𝒶𝓍i                                                      
           if i ∈ (axes)(var"𝛥≪rand(10)≫", 1)                                
               var"𝛥≪rand(10)≫"[i] = var"𝛥≪rand(10)≫"[i] + 𝛥ℛ[i]             
           else                                                              
               (zero)((eltype)(var"𝛥≪rand(10)≫"))                            
           end                                                               
       end  # similar output to before:
ERROR: LoadError: Don't know how to handle expression.
if i ∈ axes(var"𝛥≪rand(10)≫", 1)
    #= REPL[10]:3 =#
    var"𝛥≪rand(10)≫"[i] = var"𝛥≪rand(10)≫"[i] + 𝛥ℛ[i]
else
    #= REPL[10]:5 =#
    zero(eltype(var"𝛥≪rand(10)≫"))
end
Stacktrace:
 [1] push!(ls::LoopVectorization.LoopSet, ex::Expr, elementbytes::Int64, position::Int64)
   @ LoopVectorization ~/.julia/dev/LoopVectorization/src/graphs.jl:754
 [2] add_block!
...
```