### PR TITLE
Increase the `ELAPSED_MINUTES` test limit from two hours to three hours

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,4 +79,4 @@ const RUN_SLOW_TESTS = LoopVectorization.REGISTER_COUNT ≤ 16 || !parse(Bool, g
 end
 
 const ELAPSED_MINUTES = (time() - START_TIME)/60
-@test ELAPSED_MINUTES < 120
+@test ELAPSED_MINUTES < 180


### PR DESCRIPTION
On the most recent commit to `master`, one job took [2h 20m 9s](https://github.com/chriselrod/LoopVectorization.jl/runs/1545836570) and another job took [2h 12m 46s](https://github.com/chriselrod/LoopVectorization.jl/runs/1546008232).

So let's increase the limit from two hours to three hours.

(In the commit message, I wrote "two hours to four hours", which is a typo. As seen in the diff, the actual change in "two hours to three hours".)