### PR TITLE
Docs only: Replace Unicode subscript i (resp. j, l, m, n, s) with _i (resp. _j, _l, _m, _n, _s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,11 @@ Note that loops will be faster than broadcasting in general. This is because the
 ```julia
 julia> function AmulBtest!(C,A,Bk,Bn,d)
           @avx for m ∈ axes(A,1), n ∈ axes(Bk,2)
-             ΔCₘₙ = zero(eltype(C))
+             ΔC_m_n = zero(eltype(C))
              for k ∈ axes(A,2)
-                ΔCₘₙ += A[m,k] * (Bk[k,n] + Bn[n,k])
+                ΔC_m_n += A[m,k] * (Bk[k,n] + Bn[n,k])
              end
-             C[m,n] = ΔCₘₙ + d[m]
+             C[m,n] = ΔC_m_n + d[m]
           end
        end
 AmulBtest! (generic function with 1 method)

--- a/docs/src/examples/array_interface.md
+++ b/docs/src/examples/array_interface.md
@@ -15,11 +15,11 @@ using StaticArrays, LoopVectorization
 
 @inline function AmulB!(C, A, B)
     @avx for n ∈ axes(C,2), m ∈ axes(C,1)
-        Cₘₙ = zero(eltype(C))
+        C_m_n = zero(eltype(C))
         for k ∈ axes(B,1)
-            Cₘₙ += A[m,k] * B[k,n]
+            C_m_n += A[m,k] * B[k,n]
         end
-        C[m,n] = Cₘₙ
+        C[m,n] = C_m_n
     end
     C
 end
@@ -41,19 +41,19 @@ function runbenches(sr, ::Type{T}, fa = identity, fb = identity) where {T}
     bench_results = Matrix{Float64}(undef, length(sr), 4);
     for (i,s) ∈ enumerate(sr)
         M, K, N = matdims(s)
-        Aₘ = @MMatrix rand(T, M, K)
-        Bₘ = @MMatrix rand(T, K, N)
-        Aₛ = Ref(SMatrix(Aₘ));
-        Bₛ = Ref(SMatrix(Bₘ));
-        Cₛₛ = fa(Aₛ[]) * fb(Bₛ[]);
-        Cₛₗ = AmulB(fa(Aₛ[]), fb(Bₛ[]))
-        Cₘₛ = similar(Cₛₛ); mul!(Cₘₛ, fa(Aₘ), fb(Bₘ));
-        Cₘₗ = similar(Cₛₛ); AmulB!(Cₘₗ, fa(Aₘ), fb(Bₘ));
-        @assert Array(Cₛₛ) ≈ Array(Cₛₗ) ≈ Array(Cₘₛ) ≈ Array(Cₘₗ) # Once upon a time Julia crashed on ≈ for large static arrays
-        bench_results[i,1] = @belapsed $fa($Aₛ[]) * $fb($Bₛ[])
-        bench_results[i,2] = @belapsed AmulB($fa($Aₛ[]), $fb($Bₛ[]))
-        bench_results[i,3] = @belapsed mul!($Cₘₛ, $fa($Aₘ), $fb($Bₘ))
-        bench_results[i,4] = @belapsed AmulB!($Cₘₗ, $fa($Aₘ), $fb($Bₘ))
+        A_m = @MMatrix rand(T, M, K)
+        B_m = @MMatrix rand(T, K, N)
+        A_s = Ref(SMatrix(A_m));
+        B_s = Ref(SMatrix(B_m));
+        C_s_s = fa(A_s[]) * fb(B_s[]);
+        C_s_l = AmulB(fa(A_s[]), fb(B_s[]))
+        C_m_s = similar(C_s_s); mul!(C_m_s, fa(A_m), fb(B_m));
+        C_m_l = similar(C_s_s); AmulB!(C_m_l, fa(A_m), fb(B_m));
+        @assert Array(C_s_s) ≈ Array(C_s_l) ≈ Array(C_m_s) ≈ Array(C_m_l) # Once upon a time Julia crashed on ≈ for large static arrays
+        bench_results[i,1] = @belapsed $fa($A_s[]) * $fb($B_s[])
+        bench_results[i,2] = @belapsed AmulB($fa($A_s[]), $fb($B_s[]))
+        bench_results[i,3] = @belapsed mul!($C_m_s, $fa($A_m), $fb($B_m))
+        bench_results[i,4] = @belapsed AmulB!($C_m_l, $fa($A_m), $fb($B_m))
         @show s, bench_results[i,:]
     end
     gflops = @. 1e-9 * matflop(sr) / bench_results
@@ -94,11 +94,11 @@ C_hybrid = HybridArray{Tuple{StaticArrays.Dynamic(),StaticArrays.Dynamic(),3,3}}
 # B is K x N x L x J
 function bmul!(C, A, B)
     @avx for n in axes(C,2), m in axes(C,1), j in axes(C,4), i in axes(C,3)
-        Cₘₙⱼᵢ = zero(eltype(C))
+        C_m_n_j_i = zero(eltype(C))
         for k in axes(B,1), l in axes(B,3)
-            Cₘₙⱼᵢ += A[m,k,i,l] * B[k,n,l,j]
+            C_m_n_j_i += A[m,k,i,l] * B[k,n,l,j]
         end
-        C[m,n,i,j] = Cₘₙⱼᵢ
+        C[m,n,i,j] = C_m_n_j_i
     end
 end
 ```

--- a/docs/src/examples/matrix_multiplication.md
+++ b/docs/src/examples/matrix_multiplication.md
@@ -7,11 +7,11 @@ We can write a single function:
 ```julia
 function A_mul_B!(𝐂, 𝐀, 𝐁)
     @avx for m ∈ axes(𝐀,1), n ∈ axes(𝐁,2)
-        𝐂ₘₙ = zero(eltype(𝐂))
+        𝐂_m_n = zero(eltype(𝐂))
         for k ∈ axes(𝐀,2)
-            𝐂ₘₙ += 𝐀[m,k] * 𝐁[k,n]
+            𝐂_m_n += 𝐀[m,k] * 𝐁[k,n]
         end
-        𝐂[m,n] = 𝐂ₘₙ
+        𝐂[m,n] = 𝐂_m_n
     end
 end
 ```

--- a/docs/src/examples/matrix_vector_ops.md
+++ b/docs/src/examples/matrix_vector_ops.md
@@ -5,11 +5,11 @@ Here I'll discuss a variety of Matrix-vector operations, naturally starting with
 ```julia
 function jgemvavx!(𝐲, 𝐀, 𝐱)
     @avx for i ∈ eachindex(𝐲)
-        𝐲ᵢ = zero(eltype(𝐲))
+        𝐲_i = zero(eltype(𝐲))
         for j ∈ eachindex(𝐱)
-            𝐲ᵢ += 𝐀[i,j] * 𝐱[j]
+            𝐲_i += 𝐀[i,j] * 𝐱[j]
         end
-        𝐲[i] = 𝐲ᵢ
+        𝐲[i] = 𝐲_i
     end
 end
 ```


### PR DESCRIPTION
Since some users (e.g. macOS users with only the default system fonts) might not be able to render the subscripts.